### PR TITLE
Pass to pip all annotations for local requirements

### DIFF
--- a/.changelog/_unreleased.toml
+++ b/.changelog/_unreleased.toml
@@ -1,0 +1,5 @@
+[[changelog.entries]]
+id = "de9b2511-4259-48e3-98eb-62860e75ab88"
+type = "improvement"
+description = "Allow extra features in local requirements"
+author = "@Tpt"

--- a/src/kraken/common/_requirements.py
+++ b/src/kraken/common/_requirements.py
@@ -21,11 +21,11 @@ def parse_requirement(value: str) -> "PipRequirement | LocalRequirement":
     Parse a string as a requirement. Return a :class:`PipRequirement` or :class:`LocalRequirement`.
     """
 
-    match = re.match(r"(.+?)@(.+)", value)
+    match = re.match(r"([a-zA-Z0-9-_.]+)([^@]*)@(.+)", value)
     if match:
-        return LocalRequirement(match.group(1).strip(), Path(match.group(2).strip()))
+        return LocalRequirement(match.group(1).strip(), Path(match.group(3).strip()), match.group(2).strip() or None)
 
-    match = re.match(r"([\w\d\-\_]+)(.*)", value)
+    match = re.match(r"([a-zA-Z0-9-_.]+)(.*)", value)
     if match:
         return PipRequirement(match.group(1), match.group(2).strip() or None)
 
@@ -48,7 +48,7 @@ class PipRequirement(Requirement):
     """Represents a Pip requriement."""
 
     name: str
-    spec: "str | None"
+    spec: "str | None" = None
 
     def __str__(self) -> str:
         return f"{self.name}{self.spec or ''}"
@@ -65,12 +65,13 @@ class LocalRequirement(Requirement):
 
     name: str
     path: Path
+    spec: "str | None" = None
 
     def __str__(self) -> str:
-        return f"{self.name}@{self.path}"
+        return f"{self.name}{self.spec or ''}@{self.path}"
 
     def to_args(self, base_dir: Path) -> List[str]:
-        return [str((base_dir / self.path if base_dir else self.path).absolute())]
+        return [f"{self.name}{self.spec or ''}@{(base_dir / self.path if base_dir else self.path).absolute().as_uri()}"]
 
 
 @dataclasses.dataclass(frozen=True)

--- a/src/kraken/common/_requirements_test.py
+++ b/src/kraken/common/_requirements_test.py
@@ -25,6 +25,13 @@ def test__parse_requirement__can_handle_local_requirements() -> None:
     assert parse_requirement("kraken-std@.") == LocalRequirement("kraken-std", Path("."))
     assert parse_requirement("abc @ ./abc") == LocalRequirement("abc", Path("./abc"))
     assert parse_requirement("abc@/module/at/abc") == LocalRequirement("abc", Path("/module/at/abc"))
+    assert parse_requirement("abc[foo]@/module/at/abc") == LocalRequirement("abc", Path("/module/at/abc"), "[foo]")
+
+
+def test__local_requirements__to_args() -> None:
+    assert LocalRequirement("abc", Path("."), "[foo]").to_args(Path("/test")) == ["abc[foo]@file:///test"]
+    assert LocalRequirement("abc", Path("/foo"), "[foo]").to_args(Path("/test")) == ["abc[foo]@file:///foo"]
+    assert LocalRequirement("abc", Path("/foo")).to_args(Path()) == ["abc@file:///foo"]
 
 
 def test__deprecated_get_requirement_spec_from_file_header() -> None:


### PR DESCRIPTION
Implemented by making sure that the generated requirement string given to pip is valid according to PEP 508

PEP 508: https://peps.python.org/pep-0508/